### PR TITLE
Add SQLite export utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,5 @@ The following files are generated in the current directory:
 - `統合スクレイピング結果.csv` – CSV backup. If Excel export fails, `統合スクレイピング結果_エラー時.csv` is saved instead.
 - `中間保存_<番号>件.xlsx` – periodic backups every 10 processed URLs.
 - `緊急保存_スクレイピング結果.csv` – emergency backup written when an exception stops the run.
+- `scraped_data.db` – SQLite database storing the results.
 

--- a/db_utils.py
+++ b/db_utils.py
@@ -1,0 +1,18 @@
+import sqlite3
+import pandas as pd
+
+
+def save_to_sqlite(df: pd.DataFrame, db_path: str, table_name: str = 'scraped_data') -> None:
+    """Save a DataFrame to a SQLite database.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame to save.
+    db_path : str
+        Path to the SQLite database file.
+    table_name : str
+        Name of the table to write to. Defaults to 'scraped_data'.
+    """
+    with sqlite3.connect(db_path) as conn:
+        df.to_sql(table_name, conn, if_exists='replace', index=False)

--- a/total_Scraping.py
+++ b/total_Scraping.py
@@ -6,6 +6,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from webdriver_manager.chrome import ChromeDriverManager
 import time
+from db_utils import save_to_sqlite
 
 def setup_webdriver():
     """WebDriverの設定と初期化"""
@@ -438,6 +439,8 @@ def main():
         # 結果をDataFrameに変換
         scraped_data = pd.DataFrame(scraped_data_list)
         
+        # SQLiteにも保存
+        save_to_sqlite(scraped_data, "scraped_data.db")
         # 最終結果をExcelファイルに出力
         output_filename = "統合スクレイピング結果.xlsx"
         success = save_to_excel_with_formatting(scraped_data, output_filename)


### PR DESCRIPTION
## Summary
- add `db_utils.py` with a helper to save a DataFrame to SQLite
- store scraped results in `scraped_data.db`
- document the new database output in README

## Testing
- `python -m py_compile db_utils.py total_Scraping.py`