### PR TITLE
Add append support to SQLite save

### DIFF
--- a/db_utils.py
+++ b/db_utils.py
@@ -2,7 +2,12 @@ import sqlite3
 import pandas as pd
 
 
-def save_to_sqlite(df: pd.DataFrame, db_path: str, table_name: str = 'scraped_data') -> None:
+def save_to_sqlite(
+    df: pd.DataFrame,
+    db_path: str,
+    table_name: str = 'scraped_data',
+    append: bool = False,
+) -> None:
     """Save a DataFrame to a SQLite database.
 
     Parameters
@@ -13,6 +18,18 @@ def save_to_sqlite(df: pd.DataFrame, db_path: str, table_name: str = 'scraped_da
         Path to the SQLite database file.
     table_name : str
         Name of the table to write to. Defaults to 'scraped_data'.
+    append : bool
+        If True, append records to an existing table. Otherwise the table is
+        replaced.
     """
+
+    df_with_timestamp = df.copy()
+    df_with_timestamp["timestamp"] = pd.Timestamp.now()
+
     with sqlite3.connect(db_path) as conn:
-        df.to_sql(table_name, conn, if_exists='replace', index=False)
+        df_with_timestamp.to_sql(
+            table_name,
+            conn,
+            if_exists='append' if append else 'replace',
+            index=False,
+        )

--- a/total_Scraping.py
+++ b/total_Scraping.py
@@ -6,6 +6,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from webdriver_manager.chrome import ChromeDriverManager
 import time
+import os
 from db_utils import save_to_sqlite
 
 def setup_webdriver():
@@ -435,7 +436,9 @@ def main():
         scraped_data = pd.DataFrame(scraped_data_list)
         
         # SQLiteにも保存
-        save_to_sqlite(scraped_data, "scraped_data.db")
+        db_path = "scraped_data.db"
+        append = os.path.exists(db_path)
+        save_to_sqlite(scraped_data, db_path, append=append)
         # 最終結果をExcelファイルに出力
         output_filename = "統合スクレイピング結果.xlsx"
         success = save_to_excel_with_formatting(scraped_data, output_filename)


### PR DESCRIPTION
## Summary
- allow `save_to_sqlite` to append instead of always replacing
- add a timestamp column to track run time
- append to the database in `total_Scraping.py` when the DB already exists

## Testing
- `python -m py_compile db_utils.py total_Scraping.py`
