### PR TITLE
Add license and unit tests

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,35 @@
+import os
+import sqlite3
+import pandas as pd
+
+from db_utils import save_to_sqlite
+from total_Scraping import clean_data_for_excel
+
+
+def test_clean_data_for_excel():
+    long_text = 'x' * 33000
+    df = pd.DataFrame({
+        'col1': [None, 'hello\r\nworld'],
+        'col2': [long_text, 'short']
+    })
+
+    cleaned = clean_data_for_excel(df)
+
+    assert cleaned.loc[0, 'col1'] == ''
+    assert cleaned.loc[1, 'col1'] == 'hello\nworld'
+    assert cleaned.loc[0, 'col2'].startswith('x' * 32000)
+    assert cleaned.loc[0, 'col2'].endswith('...')
+    assert len(cleaned.loc[0, 'col2']) == 32003
+    # all columns converted to string
+    assert cleaned.dtypes.eq('object').all()
+
+
+def test_save_to_sqlite(tmp_path):
+    df = pd.DataFrame({'a': [1, 2], 'b': ['x', 'y']})
+    db_file = tmp_path / 'test.db'
+    save_to_sqlite(df, str(db_file), table_name='tbl')
+
+    with sqlite3.connect(db_file) as conn:
+        result = pd.read_sql('SELECT * FROM tbl', conn)
+
+    pd.testing.assert_frame_equal(df, result)


### PR DESCRIPTION
## Summary
- add MIT license file
- provide basic unit tests for `clean_data_for_excel` and `save_to_sqlite`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*